### PR TITLE
Wrong type for Flickr response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class Response
 {
-    protected object $contents;
+    protected array $contents;
 
     public function __construct(ResponseInterface $guzzleResponse)
     {


### PR DESCRIPTION
Unserializing the Flickr response yields an array and not an object. With modern PHP assigning an array to an object throws a TypeError.